### PR TITLE
Fix orientation frame

### DIFF
--- a/src/novatel_oem7_driver/src/odometry_handler.cpp
+++ b/src/novatel_oem7_driver/src/odometry_handler.cpp
@@ -291,9 +291,9 @@ namespace novatel_oem7_driver
       tf2::Transform local_tf(orientation); // Twist is rotated into local frame
       tf2::Transform local_tf_inv = local_tf.inverse();
 
-      // orientation is from utm to base link, needs to account for meridian.
+      // orientation is in local ENU form track heading, but odom is in UTM, so we need to rotate it
       tf2::Quaternion meridian_rotation;
-      meridian_rotation.setRPY(0., 0., -meridian_convergence_);
+      meridian_rotation.setRPY(0., 0., -meridian_convergence_); 
       orientation = meridian_rotation * orientation;
       odometry_.pose.pose.orientation = tf2::toMsg(orientation);
 

--- a/src/novatel_oem7_driver/src/odometry_handler.cpp
+++ b/src/novatel_oem7_driver/src/odometry_handler.cpp
@@ -331,12 +331,22 @@ namespace novatel_oem7_driver
         // Linear velocity in local ENU
         // N.B. gpsfix_->track is in NED and in degrees
         double track_ground_rad = degreesToRadians(gpsfix_->track);
-        double sin_trk = std::sin(track_ground_rad);
-        double cos_trk = std::cos(track_ground_rad);
+        // double sin_trk = std::sin(track_ground_rad);
+        // double cos_trk = std::cos(track_ground_rad);
+        // this is corrected yaw in UTM
+        double roll_temp, pitch_temp, yaw_temp;
+        tf2::Matrix3x3(orientation).getRPY(roll_temp, pitch_temp, yaw_temp); 
+        double sin_yaw = std::sin(yaw_temp);
+        double cos_yaw = std::cos(yaw_temp);
+        // using corrected yaw in UTM to get local linear velocity
         tf2::Vector3 local_linear_velocity = local_tf_inv(tf2::Vector3(
-                                                                  gpsfix_->speed * sin_trk,
-                                                                  gpsfix_->speed * cos_trk,
-                                                                  gpsfix_->climb));
+                                                              gpsfix_->speed * sin_yaw,
+                                                              gpsfix_->speed * cos_yaw,
+                                                              gpsfix_->climb));
+        // tf2::Vector3 local_linear_velocity = local_tf_inv(tf2::Vector3(
+        //                                                           gpsfix_->speed * sin_trk,
+        //                                                           gpsfix_->speed * cos_trk,
+        //                                                           gpsfix_->climb));
         odometry_.twist.twist.linear.x = local_linear_velocity.x();
         odometry_.twist.twist.linear.y = local_linear_velocity.y();
         odometry_.twist.twist.linear.z = local_linear_velocity.z();

--- a/src/novatel_oem7_driver/src/odometry_handler.cpp
+++ b/src/novatel_oem7_driver/src/odometry_handler.cpp
@@ -292,9 +292,9 @@ namespace novatel_oem7_driver
       tf2::Transform local_tf_inv = local_tf.inverse();
 
       // orientation is from utm to base link, needs to account for meridian.
-      //tf2::Quaternion meridian_rotation;
-      //meridian_rotation.setRPY(0., 0., meridian_convergence_);
-      //orientation = meridian_rotation * orientation;
+      tf2::Quaternion meridian_rotation;
+      meridian_rotation.setRPY(0., 0., -meridian_convergence_);
+      orientation = meridian_rotation * orientation;
       odometry_.pose.pose.orientation = tf2::toMsg(orientation);
 
       odometry_.pose.covariance[21] = std::pow(std::atan2(0.3, gpsfix_->speed), 2); 


### PR DESCRIPTION
The orientation used in odom handler is gps track heading and it is in local enu
Header of the Odom topic is UTM
As a result, the orientation yaw need to be rotated to reflect the angle in UTM
meridian convergence is get in the handler function
From enu to UTM, the angle should be a negative
Test with code in localization:

- define a Quaternion with 0 yaw angle
- get meridian convergence value
- define rotation matrix with -meridian convergence
- multiply rotation matrix and yaw 

![image](https://github.com/user-attachments/assets/f6a2fd93-583d-483a-b59a-9c10e3d96271)

- expected result would be the orientation after rotated should be larger than 0 at vegas track
- the log result of rotated value is 0.02 rad as expected
![image](https://github.com/user-attachments/assets/2b7d87d1-e95f-43f5-8ba4-e5992f99cde7)
